### PR TITLE
Upgrade deprecated ember-oo-modifier to ember-modifier

### DIFF
--- a/addon/modifiers/rdfa.js
+++ b/addon/modifiers/rdfa.js
@@ -1,4 +1,4 @@
-import { Modifier } from 'ember-oo-modifiers';
+import Modifier from 'ember-modifier';
 
 const rdfaKeywords = [
   'resource',
@@ -14,13 +14,21 @@ const rdfaKeywords = [
   'prefix'
 ];
 
-const RdfaModifier = Modifier.extend({
-  didReceiveArguments( [rdfaAttributes] ) {
+export default class RdfaModifier extends Modifier {
+
+  constructor(){
+    super(...arguments)
+  }
+
+  get rdfaAttributes(){
+    return this.args.positional[0]
+  }
+
+  didReceiveArguments(e) {
     for (let key of rdfaKeywords) {
-      if (rdfaAttributes[key])
-        this.element.setAttribute(key, rdfaAttributes[key]);
+      if (this.rdfaAttributes[key])
+        this.element.setAttribute(key, this.rdfaAttributes[key]);
     }
   }
-});
 
-export default Modifier.modifier(RdfaModifier);
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-href-to": "^3.1.0",
-    "ember-oo-modifiers": "^0.3.0"
+    "ember-modifier": "^2.1.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",


### PR DESCRIPTION
- Tested it extensively see rdfa.js commit message. 
- Resolved the `Custom modifier managers must define their capabilities using the capabilities() helper function` errors in frontend-mandatendatabank. 
- New syntax is written by the book: [Ember-modifier class syntax here](https://github.com/ember-modifier/ember-modifier#class-based)