### PR TITLE
Remove the internal usage of the `{{rdfa}}` modifier

### DIFF
--- a/addon/templates/components/rdfa/ctx-each.hbs
+++ b/addon/templates/components/rdfa/ctx-each.hbs
@@ -13,13 +13,13 @@
           {{#if (has-block)}}
             {{yield (hash property=rdfaProperty href=newModel.uri typeof=newModel.rdfaBindings.class) newModel componentHash index}}
           {{else}}
-            <a {{rdfa (hash property=rdfaProperty href=newModel.uri typeof=newModel.rdfaBindings.class)}}>{{newModel.uri}}</a>
+            <a property={{this.rdfaProperty}} href={{newModel.uri}} typeof={{newModel.rdfaBindings.class}}>{{newModel.uri}}</a>
           {{/if}}
         {{else}}
           {{#if (has-block)}}
             {{yield (hash property=rdfaProperty resource=newModel.uri typeof=newModel.rdfaBindings.class) newModel componentHash index}}
           {{else}}
-            <span {{rdfa (hash property=rdfaProperty resource=newModel.uri typeof=newModel.rdfaBindings.class)}}>{{newModel.uri}}</span>
+            <span property={{this.rdfaProperty}} resource={{newModel.uri}} typeof={{newModel.rdfaBindings.class}}>{{newModel.uri}}</span>
           {{/if}}
         {{/if}}
       {{else}}
@@ -27,13 +27,13 @@
           {{#if (has-block)}}
             {{yield (hash property=rdfaProperty href=newModel) index}}
           {{else}}
-            <a {{rdfa (hash property=rdfaProperty href=newModel)}}>{{newModel}}</a>
+            <a property={{this.rdfaProperty}} href={{newModel}}>{{newModel}}</a>
           {{/if}}
         {{else}}
           {{#if (has-block)}}
             {{yield (hash property=rdfaProperty datatype=rdfaDatatype content=rdfaContent) newModel index}}
           {{else}}
-            <span {{rdfa (hash property=rdfaProperty datatype=rdfaDatatype content=rdfaContent)}}>{{newModel}}</span>
+            <span property={{this.rdfaProperty}} datatype={{this.rdfaDatatype}} content={{this.rdfaContent}}>{{newModel}}</span>
           {{/if}}
         {{/if}}
       {{/if}}

--- a/addon/templates/components/rdfa/ctx-get.hbs
+++ b/addon/templates/components/rdfa/ctx-get.hbs
@@ -14,14 +14,14 @@
         {{#if (has-block)}}
           {{yield (hash property=rdfaProperty href=value.uri typeof=typeof) value componentHash}}
         {{else}}
-          <a {{rdfa (hash property=rdfaProperty href=value.uri typeof=typeof)}}>{{value.uri}}</a>
+          <a property={{this.rdfaProperty}} href={{this.value.uri}} typeof={{this.typeof}}>{{this.value.uri}}</a>
         {{/if}}
       {{else}}
         {{!-- We want to create a new scope for the resource --}}
         {{#if (has-block)}}
           {{yield (hash property=rdfaProperty resource=value.uri typeof=typeof) value componentHash}}
         {{else}}
-          <span {{rdfa (hash property=rdfaProperty resource=value.uri typeof=typeof)}}>{{value.uri}}</span>
+          <span property={{this.rdfaProperty}} resource={{this.value.uri}} typeof={{this.typeof}}>{{this.value.uri}}</span>
         {{/if}}
       {{/if}}
     {{else}}
@@ -30,13 +30,13 @@
         {{#if (has-block)}}
           {{yield (hash property=rdfaProperty href=value)}}
         {{else}}
-          <a {{rdfa (hash property=rdfaProperty href=value)}}>{{value}}</a>
+          <a property={{this.rdfaProperty}} href={{this.value}}>{{this.value}}</a>
         {{/if}}
       {{else}}
         {{#if (has-block)}}
           {{yield (hash property=rdfaProperty datatype=rdfaDatatype content=rdfaContent) value}}
         {{else}}
-          <span {{rdfa (hash property=rdfaProperty datatype=rdfaDatatype content=rdfaContent)}}>{{value}}</span>
+          <span property={{this.rdfaProperty}} datatype={{this.rdfaDatatype}} content={{this.rdfaContent}}>{{this.value}}</span>
         {{/if}}
       {{/if}}
     {{/if}}

--- a/addon/templates/components/rdfa/link-to.hbs
+++ b/addon/templates/components/rdfa/link-to.hbs
@@ -1,9 +1,9 @@
-{{#if useUri}}
-  <a href={{uri}} {{rdfa (hash property=property typeof=typeof)}} {{action "transition"}}>
-    {{yield}}
-  </a>
-{{else}}
-  <a href={{url}} {{rdfa (hash property=property typeof=typeof resource=uri)}} {{action "transition"}}>
-    {{yield}}
-  </a>
-{{/if}}
+<a
+  href={{if this.useUri this.uri this.url}}
+  property={{this.property}}
+  typeof={{this.typeof}}
+  resource={{if this.useUri undefined this.uri}}
+  {{action "transition"}}
+>
+  {{yield}}
+</a>


### PR DESCRIPTION
Modifiers aren't executed in FastBoot which means some attributes are not applied when the host application uses a component in its inline form.

